### PR TITLE
feat(multi-select): add clearSearchOnChange and fix selection-loss bugs

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @glasshouse/components
 
+## 0.10.0
+
+### Minor Changes
+
+- MultiSelect: improve search and selection behavior
+
+  - Add `clearSearchOnChange` prop (default `false`). By default the search text and the filtered result list are now kept after selecting an option, so users can keep picking multiple items from the same search without retyping. Set `clearSearchOnChange` to `true` to clear the search on every change (the previous behavior).
+  - Hide the clear-all (`X`) button while the dropdown is open to avoid accidentally wiping all selections during search.
+  - Stop removing the last selected item when pressing Backspace on an empty search input.
+
 ## 0.9.29
 
 ### Patch Changes

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@glasshouse/components",
-	"version": "0.9.29",
+	"version": "0.10.0",
 	"homepage": "https://github.com/GlasshouseVentureStudio/glasshouse-stack/tree/main/packages/components",
 	"repository": {
 		"type": "git",

--- a/packages/components/src/multi-select/multi-select.base.tsx
+++ b/packages/components/src/multi-select/multi-select.base.tsx
@@ -37,6 +37,7 @@ const defaultProps: Partial<MultiSelectBaseProps> = {
 	withCheckIcon: true,
 	checkIconPosition: 'left',
 	hiddenInputValuesDivider: ',',
+	clearSearchOnChange: false,
 };
 
 const MultiSelectBaseComponent = (_props: MultiSelectBaseProps, ref: ForwardedRef<HTMLInputElement>) => {
@@ -143,6 +144,7 @@ const MultiSelectBaseComponent = (_props: MultiSelectBaseProps, ref: ForwardedRe
 		onDropdownEndReached,
 		virtualized,
 		virtualizerOptions,
+		clearSearchOnChange,
 		...others
 	} = props;
 
@@ -275,16 +277,6 @@ const MultiSelectBaseComponent = (_props: MultiSelectBaseProps, ref: ForwardedRe
 			event.preventDefault();
 			combobox.toggleDropdown();
 		}
-
-		if (event.key === 'Backspace' && _searchValue.length === 0 && _value.length > 0) {
-			const val = _value[_value.length - 1];
-
-			if (val) {
-				onRemove?.(val);
-			}
-
-			setValue(_value.slice(0, _value.length - 1));
-		}
 	};
 
 	useEffect(() => {
@@ -293,7 +285,7 @@ const MultiSelectBaseComponent = (_props: MultiSelectBaseProps, ref: ForwardedRe
 		}
 	}, [selectFirstOptionOnChange, _value, combobox]);
 
-	const clearButton = clearable && _value.length > 0 && !disabled && !readOnly && (
+	const clearButton = clearable && _value.length > 0 && !disabled && !readOnly && !combobox.dropdownOpened && (
 		<Combobox.ClearButton
 			size={size}
 			{...clearButtonProps}
@@ -406,7 +398,11 @@ const MultiSelectBaseComponent = (_props: MultiSelectBaseProps, ref: ForwardedRe
 
 	const handleOptionSubmit = (value: string) => {
 		onOptionSubmit?.(value);
-		setSearchValue('');
+
+		if (clearSearchOnChange) {
+			setSearchValue('');
+		}
+
 		combobox.updateSelectedOptionIndex('selected');
 
 		const option = optionsLockup[value];

--- a/packages/components/src/multi-select/multi-select.types.ts
+++ b/packages/components/src/multi-select/multi-select.types.ts
@@ -164,6 +164,17 @@ export interface MultiSelectBaseProps extends MantineMultiSelectProps {
 	/** A boolean that determines whether the options list should use virtualization. */
 	virtualized?: boolean;
 
+	/**
+	 * Whether to clear the search value when the selected value changes (an option is selected or deselected).
+	 *
+	 * By default the search text and the filtered result list are kept after a selection, so users can continue
+	 * picking multiple items from the same search without retyping. Set to `true` to clear the search on every
+	 * change. The search is always cleared when the input is blurred, the dropdown is reopened, or the value is cleared.
+	 *
+	 * @defaultValue `false`
+	 */
+	clearSearchOnChange?: boolean;
+
 	/** Options for the virtualizer.
 	 * @see https://tanstack.com/virtual/latest/docs/api/virtualizer
 	 */

--- a/packages/components/src/multi-select/stories/multi-select.stories.tsx
+++ b/packages/components/src/multi-select/stories/multi-select.stories.tsx
@@ -60,6 +60,17 @@ export const Basic: StoryObj<MultiSelectStory> = {
 	},
 };
 
+export const KeepSearchValue: StoryObj<MultiSelectStory> = {
+	args: {
+		data: generateData(20),
+		w: 256,
+		placeholder: 'Select person',
+		searchable: true,
+		clearable: true,
+		clearSearchOnChange: false,
+	},
+};
+
 export const RenderOption: StoryObj<MultiSelectProps> = {
 	args: {
 		data: generateData(20),


### PR DESCRIPTION
- Add `clearSearchOnChange` prop (default false) to keep search and filtered results after select.
- Hide the clear-all button while the dropdown is open.
- Stop removing the last selected item when pressing Backspace on an empty search input.